### PR TITLE
IDBCursorWithValue->IDBCursor

### DIFF
--- a/IndexedDB/idbcursor_continue_index2.htm
+++ b/IndexedDB/idbcursor_continue_index2.htm
@@ -38,7 +38,7 @@
             assert_throws("DataError",
                 function() { cursor.continue(document); });
 
-            assert_true(cursor instanceof IDBCursorWithValue, "cursor");
+            assert_true(cursor instanceof IDBCursor, "cursor");
 
             t.done();
         });


### PR DESCRIPTION
According to the draft spec (as opposed to the Recommendation), only `openKeyCursor` could create a cursor which implements `IDBCursorWithValue`. Otherwise, it should be `IDBCursor`.
